### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,46 +6,46 @@
 # Datatypes (KEYWORD1)
 ################################################
 
-SMSLinear						KEYWORD1
-SMSSmooth						KEYWORD1
-SMSSmoothBounce 		KEYWORD1
-SlowMotionServo 		KEYWORD1
+SMSLinear	KEYWORD1
+SMSSmooth	KEYWORD1
+SMSSmoothBounce	KEYWORD1
+SlowMotionServo	KEYWORD1
 
 ################################################
 # Methods and Functions (KEYWORD2)
 ################################################
 
-setMin							KEYWORD2
-setMax							KEYWORD2
-setMinMax						KEYWORD2
-setReverted     		KEYWORD2
-setPin							KEYWORD2
-setMinToMaxSpeed		KEYWORD2
-setMaxToMinSpeed		KEYWORD2
-setSpeed						KEYWORD2
+setMin	KEYWORD2
+setMax	KEYWORD2
+setMinMax	KEYWORD2
+setReverted	KEYWORD2
+setPin	KEYWORD2
+setMinToMaxSpeed	KEYWORD2
+setMaxToMinSpeed	KEYWORD2
+setSpeed	KEYWORD2
 setInitialPosition	KEYWORD2
-goTo								KEYWORD2
-goToMin							KEYWORD2
-goToMax							KEYWORD2
-setDetachAtMin			KEYWORD2
-setDetachAtMax			KEYWORD2
-setDetach						KEYWORD2
-isStopped						KEYWORD2
-setDelayUntilStop		KEYWORD2
-update							KEYWORD2
-pin									KEYWORD2
-detachAtMin					KEYWORD2
-detachAtMax					KEYWORD2
-minimumPulse				KEYWORD2
-maximumPulse				KEYWORD2
-minToMaxSpeed				KEYWORD2
-maxToMinSpeed				KEYWORD2
-isReverted					KEYWORD2
-setupMin						KEYWORD2
-setupMax						KEYWORD2
-adjustMin						KEYWORD2
-adjustMax						KEYWORD2
-endSetup						KEYWORD2
+goTo	KEYWORD2
+goToMin	KEYWORD2
+goToMax	KEYWORD2
+setDetachAtMin	KEYWORD2
+setDetachAtMax	KEYWORD2
+setDetach	KEYWORD2
+isStopped	KEYWORD2
+setDelayUntilStop	KEYWORD2
+update	KEYWORD2
+pin	KEYWORD2
+detachAtMin	KEYWORD2
+detachAtMax	KEYWORD2
+minimumPulse	KEYWORD2
+maximumPulse	KEYWORD2
+minToMaxSpeed	KEYWORD2
+maxToMinSpeed	KEYWORD2
+isReverted	KEYWORD2
+setupMin	KEYWORD2
+setupMax	KEYWORD2
+adjustMin	KEYWORD2
+adjustMax	KEYWORD2
+endSetup	KEYWORD2
 
 ################################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords